### PR TITLE
Issue #51: Update to 2.4.53 for security issues, bugs and improvements

### DIFF
--- a/httpd-2.4.53-detect-systemd.patch
+++ b/httpd-2.4.53-detect-systemd.patch
@@ -23,19 +23,17 @@ index 2a7e5d1..eb28321 100644
          AC_DEFINE(HAVE_SYSTEMD, 1, [Define if systemd is supported])
        fi
     fi
-diff --git a/configure.in b/configure.in
-index 3618a5a..74a782b 100644
---- a/configure.in
-+++ b/configure.in
-@@ -234,6 +234,7 @@ if test "$PCRE_CONFIG" != "false"; then
+--- a/configure.in	2022-02-24 23:18:42.000000000 +0100
++++ b/configure.in	2022-03-15 09:22:30.660247473 +0100
+@@ -239,6 +239,7 @@
    AC_MSG_NOTICE([Using external PCRE library from $PCRE_CONFIG])
    APR_ADDTO(PCRE_INCLUDES, [`$PCRE_CONFIG --cflags`])
-   APR_ADDTO(PCRE_LIBS, [`$PCRE_CONFIG --libs`])
+   APR_ADDTO(PCRE_LIBS, [`$PCRE_CONFIG --libs8 2>/dev/null || $PCRE_CONFIG --libs`])
 +  APR_ADDTO(HTTPD_LIBS, [\$(PCRE_LIBS)])
  else
-   AC_MSG_ERROR([pcre-config for libpcre not found. PCRE is required and available from http://pcre.org/])
+   AC_MSG_ERROR([pcre(2)-config for libpcre not found. PCRE is required and available from http://pcre.org/])
  fi
-@@ -710,6 +711,7 @@ APACHE_SUBST(OS_DIR)
+@@ -703,6 +704,7 @@
  APACHE_SUBST(BUILTIN_LIBS)
  APACHE_SUBST(SHLIBPATH_VAR)
  APACHE_SUBST(OS_SPECIFIC_VARS)
@@ -43,3 +41,4 @@ index 3618a5a..74a782b 100644
  
  PRE_SHARED_CMDS='echo ""'
  POST_SHARED_CMDS='echo ""'
+

--- a/httpd24u.spec
+++ b/httpd24u.spec
@@ -824,10 +824,7 @@ exit $rv
 
 
 %changelog
-* Fri Oct 05 2021 Reporter4u <reporter4u@gnail.com> - 2.4.50-1
-- Latest upstream
-
-* Fri Oct 05 2021 Reporter4u <reporter4u@gnail.com> - 2.4.49-1
+* Fri Oct 05 2021 Reporter4u <reporter4u@gmail.com> - 2.4.50-1
 - Latest upstream
 
 * Fri Jun 04 2021 Steve Simpson <steven.simpson@parsons.com> - 2.4.48-1

--- a/httpd24u.spec
+++ b/httpd24u.spec
@@ -24,7 +24,7 @@
 
 Summary: Apache HTTP Server
 Name: httpd24u
-Version: 2.4.48
+Version: 2.4.49
 Release: 1%{?dist}
 URL: https://httpd.apache.org/
 Source0: https://www.apache.org/dist/httpd/httpd-%{version}.tar.bz2
@@ -824,6 +824,9 @@ exit $rv
 
 
 %changelog
+* Fri Oct 05 2021 Reporter4u <reporter4u@gnail.com> - 2.4.49-1
+- Latest upstream
+
 * Fri Jun 04 2021 Steve Simpson <steven.simpson@parsons.com> - 2.4.48-1
 - Latest upstream
 

--- a/httpd24u.spec
+++ b/httpd24u.spec
@@ -824,6 +824,9 @@ exit $rv
 
 
 %changelog
+* Fri Oct 05 2021 Reporter4u <reporter4u@gnail.com> - 2.4.50-1
+- Latest upstream
+
 * Fri Oct 05 2021 Reporter4u <reporter4u@gnail.com> - 2.4.49-1
 - Latest upstream
 

--- a/httpd24u.spec
+++ b/httpd24u.spec
@@ -24,7 +24,7 @@
 
 Summary: Apache HTTP Server
 Name: httpd24u
-Version: 2.4.49
+Version: 2.4.50
 Release: 1%{?dist}
 URL: https://httpd.apache.org/
 Source0: https://www.apache.org/dist/httpd/httpd-%{version}.tar.bz2

--- a/httpd24u.spec
+++ b/httpd24u.spec
@@ -24,7 +24,7 @@
 
 Summary: Apache HTTP Server
 Name: httpd24u
-Version: 2.4.52
+Version: 2.4.53
 Release: 1%{?dist}
 URL: https://httpd.apache.org/
 Source0: https://www.apache.org/dist/httpd/httpd-%{version}.tar.bz2
@@ -71,7 +71,7 @@ Patch3: httpd-2.4.1-deplibs.patch
 Patch6: httpd-2.4.3-apctl-systemd.patch
 Patch8: httpd-2.4.35-layout-legacy.patch
 # Needed for socket activation and mod_systemd patch
-Patch19: httpd-2.4.43-detect-systemd.patch
+Patch19: httpd-2.4.53-detect-systemd.patch
 # Features/functional changes
 Patch23: httpd-2.4.33-export.patch
 Patch24: httpd-2.4.1-corelimit.patch
@@ -827,17 +827,13 @@ exit $rv
 
 
 %changelog
-<<<<<<< HEAD
-* Wed Dec 22 2021 Reporter4u <reporter4u@gmail.com> - 2.4.52-1
-- Latest upstream
+* Mon Mar 14 2022 Reporter4u <reporter4u@gmail.com> - 2.4.53-1
+- Updated to 2.4.53 from Upstream
 
-||||||| bb31d89
-=======
 * Thu Jan 06 2022 Steve Simpson <steven.simpson@parsons.com> - 2.4.52-1
 - Updated to 2.4.52 from Upstream
 - Added patch r1894152 from FC
 
->>>>>>> 344a934e17361b90a03b142e7b22630c4f72235a
 * Fri Oct 08 2021 Steve Simpson <steven.simpson@parsons.com> - 2.4.51-1
 - Latest upstream
 


### PR DESCRIPTION
This is a pull request for issue #51: _Since version 2.4.52 Apache stalls after some time._
 
Furthermore it updates httpd24u to [2.4.53 release](https://downloads.apache.org/httpd/CHANGES_2.4.53) for security issues, bugs and improvements.

I hope you can validate it and do reviews as soon as possible.

Thank you.

Roberto